### PR TITLE
Set dout to a zero byte if read mode is not asserted

### DIFF
--- a/hdl/jtopl.v
+++ b/hdl/jtopl.v
@@ -82,7 +82,8 @@ wire          op, con_I, op_out, con_out;
 wire signed [12:0] op_result;
 
 assign          write   = !cs_n && !wr_n;
-assign          dout    = { ~irq_n, flag_A, flag_B, 5'd6 };
+assign          read    = !cs_n && !addr;
+assign          dout    = read ? { ~irq_n, flag_A, flag_B, 5'd6 } : 8'd0;
 assign          eg_stop = 0;
 
 jtopl_mmr u_mmr(


### PR DESCRIPTION
The datasheet doesn't say much about the behaviour of the status register when the `cs_n` and `addr` signals are not asserted.

It is much more useful if a zero byte is returned, as it allows the `dout` bus to be ORed, etc.
