### PR TITLE
Pass OPL_TYPE to jtopl_csr

### DIFF
--- a/hdl/jtopl_csr.v
+++ b/hdl/jtopl_csr.v
@@ -21,7 +21,7 @@
 */
 
 module jtopl_csr #(
-    parameter LEN=18, W=34
+    parameter LEN=18, W=34, OPL_TYPE=1
 ) ( // Circular Shift Register + input mux
     input           rst,
     input           clk,
@@ -70,8 +70,9 @@ assign regop_in[31:0] = { // 4 bytes:
         up_sl_rr_op ? din         : shift_out[ 7: 0]
     };
 
-`ifdef JTOPL2
-    assign regop_in[33:32] = up_wav_I ? din[1:0] : shift_out[33:32];
-`endif
+generate if (OPL_TYPE == 2) begin
+assign regop_in[33:32] = up_wav_I ? din[1:0] : shift_out[33:32];
+end
+endgenerate
 
 endmodule // jtopl_reg

--- a/hdl/jtopl_reg.v
+++ b/hdl/jtopl_reg.v
@@ -129,7 +129,7 @@ wire              en_sus, rhy_oen;
 // Sustained is disabled in rhythm mode for channels in group 2 (i.e. 6,7,8)
 assign            en_sus_I = rhy_oen ? 1'b0 : en_sus;
 
-jtopl_csr #(.LEN(CH*2),.W(OPCFGW)) u_csr(
+jtopl_csr #(.LEN(CH*2),.W(OPCFGW), .OPL_TYPE(OPL_TYPE)) u_csr(
     .rst            ( rst           ),
     .clk            ( clk           ),
     .cen            ( cen           ),


### PR DESCRIPTION
The 'define is confusing, as one might believe that setting OPL_TYPE is enough.